### PR TITLE
Scope campaign layout styles

### DIFF
--- a/src/pages/Campaigns.css
+++ b/src/pages/Campaigns.css
@@ -1,0 +1,6 @@
+#campaign-module {
+  margin: 0;
+  padding: 0;
+  max-width: none;
+}
+

--- a/src/pages/Campaigns.tsx
+++ b/src/pages/Campaigns.tsx
@@ -1,11 +1,17 @@
 import { AppLayout } from '@/components/layout/AppLayout';
 import { CampaignsPage } from '@/components/campaigns/CampaignsPage';
+import './Campaigns.css';
 
 const Campaigns = () => {
   return (
-    <AppLayout>
-      <CampaignsPage />
-    </AppLayout>
+    <section
+      id="campaign-module"
+      className="w-screen max-w-none overflow-x-hidden"
+    >
+      <AppLayout>
+        <CampaignsPage />
+      </AppLayout>
+    </section>
   );
 };
 


### PR DESCRIPTION
## Summary
- Wrap Campaigns page in dedicated `section` with module-specific wrapper
- Apply page-scoped CSS to reset layout margin, padding, and max-width

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors in unrelated files)*
- `npx eslint src/pages/Campaigns.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68c1156d0f2c83308cf7f003363022ae